### PR TITLE
Add slugged image tagging for Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -64,12 +64,13 @@ jobs:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ghcr.io/${{ github.repository }}:${{ steps.slug.outputs.suffix }}
+          load: ${{ github.event_name == 'pull_request' }}
+          tags: ghcr.io/${{ toLower(github.repository) }}:${{ steps.slug.outputs.suffix }}
 
       - name: Trivy scan image
         uses: aquasecurity/trivy-action@0.20.0
         with:
-          image-ref: ghcr.io/${{ github.repository }}:${{ steps.slug.outputs.suffix }}
+          image-ref: ghcr.io/${{ toLower(github.repository) }}:${{ steps.slug.outputs.suffix }}
           format: 'sarif'
           output: 'trivy-${{ steps.slug.outputs.suffix }}.sarif'
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,80 @@
+name: Docker
+
+on:
+  push:
+    paths:
+      - '.github/workflows/docker.yml'
+      - '**/Dockerfile'
+  pull_request:
+    paths:
+      - '.github/workflows/docker.yml'
+      - '**/Dockerfile'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build and Scan Images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: backend
+            context: ./backend
+            dockerfile: ./backend/Dockerfile
+          - name: frontend
+            context: ./frontend
+            dockerfile: ./frontend/Dockerfile
+          - name: python-worker
+            context: ./python-worker
+            dockerfile: ./python-worker/Dockerfile
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image suffix
+        id: slug
+        run: |
+          path="${{ matrix.context }}"
+          if [ -z "$path" ] || [ "$path" = "." ] || [ "$path" = "./" ]; then
+            suffix="root"
+          else
+            suffix="${path#./}"
+            suffix="${suffix//\//-}"
+          fi
+          echo "suffix=$suffix" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ghcr.io/${{ github.repository }}:${{ steps.slug.outputs.suffix }}
+
+      - name: Trivy scan image
+        uses: aquasecurity/trivy-action@0.20.0
+        with:
+          image-ref: ghcr.io/${{ github.repository }}:${{ steps.slug.outputs.suffix }}
+          format: 'sarif'
+          output: 'trivy-${{ steps.slug.outputs.suffix }}.sarif'
+
+      - name: Upload Trivy scan results
+        if: always()
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: trivy-${{ steps.slug.outputs.suffix }}.sarif


### PR DESCRIPTION
## Summary
- add a Docker workflow that builds backend, frontend, and python worker images
- derive a sanitized suffix for each image so nested Dockerfiles publish unique tags
- reuse the sanitized suffix for Trivy scans to keep security reports aligned with image tags

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e89ef45144832888b42e72852b4d6b

## Summary by Sourcery

Add a GitHub Actions workflow that builds, tags, and security scans Docker images for backend, frontend, and python-worker components using sanitized slugs.

New Features:
- Introduce a Docker workflow to build and push backend, frontend, and python-worker images
- Generate a sanitized slug based on the Dockerfile path to uniquely tag each image
- Incorporate Trivy vulnerability scans for each image and upload SARIF reports