### PR TITLE
Update docs workflow to use setup-python

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,28 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install mkdocs-material
+
+      - name: Build documentation
+        run: mkdocs build


### PR DESCRIPTION
## Summary
- add docs workflow that installs MkDocs Material using pip and builds the docs
- set up Python 3.11 on the runner before installing dependencies

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e89ef6d4208328a1cf80d42355c5a9

## Summary by Sourcery

Add a dedicated CI workflow to build the project documentation using Python 3.11 and MkDocs Material

CI:
- Add 'Docs' GitHub Actions workflow triggered on pushes and pull requests to main branch
- Set up Python 3.11 using actions/setup-python@v5
- Install MkDocs Material via pip and build the documentation with mkdocs build