### PR TITLE
Add Docker workflow sanitizing image suffix

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,80 @@
+name: Build and Publish Docker Images
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build and Push Images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - name: backend
+            context: ./backend
+            dockerfile: ./backend/Dockerfile
+          - name: frontend
+            context: ./frontend
+            dockerfile: ./frontend/Dockerfile
+          - name: python-worker
+            context: ./python-worker
+            dockerfile: ./python-worker/Dockerfile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image suffix
+        id: image-suffix
+        env:
+          RAW_CONTEXT: ${{ matrix.context }}
+        run: |
+          sanitized="${RAW_CONTEXT//\//-}"
+          sanitized="${sanitized##./}"
+          if [ -z "$sanitized" ]; then
+            sanitized="root"
+          fi
+          echo "suffix=$sanitized" >> "$GITHUB_OUTPUT"
+
+      - name: Compose image reference
+        id: image-ref
+        env:
+          REPOSITORY: ${{ github.repository }}
+          SUFFIX: ${{ steps["image-suffix"].outputs.suffix }}
+        run: |
+          echo "value=ghcr.io/${REPOSITORY}/${SUFFIX}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps["image-ref"].outputs.value }}
+          tags: |
+            type=ref,event=tag
+            type=raw,value=${{ github.sha }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Output image reference
+        run: echo "Published ${{ steps.meta.outputs.tags }}"


### PR DESCRIPTION
## Summary
- add a Docker build-and-push workflow that logs in to GHCR and iterates over project Dockerfiles
- sanitize each Docker context path into a safe suffix, defaulting to `root`, before composing the image reference
- push images using docker/metadata-action and docker/build-push-action with the sanitized tags

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e89f8283ac83288e6c4ea19907e1ed

## Summary by Sourcery

Add a GitHub Actions workflow to build and publish Docker images for multiple project contexts, sanitizing the context path into an image suffix and deploying to GHCR with metadata-based tagging

New Features:
- Introduce workflow to build and push Docker images for backend, frontend, and python-worker contexts to GHCR

Enhancements:
- Sanitize Docker context paths into hyphen-separated suffixes, defaulting to “root”

CI:
- Trigger the workflow on semantic version tag pushes and manual dispatch