### PR TITLE
Add Docker workflow with sanitized image suffixes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,9 @@ env:
 
 jobs:
   build:
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,76 @@
+name: Build and Publish Docker Images
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: backend
+            context: ./backend
+            dockerfile: ./backend/Dockerfile
+          - name: frontend
+            context: ./frontend
+            dockerfile: ./frontend/Dockerfile
+          - name: python-worker
+            context: ./python-worker
+            dockerfile: ./python-worker/Dockerfile
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image metadata
+        id: image-meta
+        env:
+          CONTEXT: ${{ matrix.context }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          raw="${CONTEXT#./}"
+          safe="${raw//\//-}"
+          if [ -z "$safe" ]; then
+            safe="root"
+          fi
+          safe="${safe,,}"
+          owner="${OWNER,,}"
+          repo="${REPO,,}"
+          image="$REGISTRY/$owner/$repo/$safe"
+          tag="${REF_NAME:-latest}"
+          echo "suffix=$safe" >> "$GITHUB_OUTPUT"
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "image-ref=$image:$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+          provenance: false
+          tags: ${{ steps.image-meta.outputs.image-ref }}
+
+      - name: Publish image reference
+        run: |
+          echo "Built image ${{ steps.image-meta.outputs.image-ref }}"


### PR DESCRIPTION
## Summary
- add a Docker build workflow that targets the backend, frontend, and python-worker images
- sanitize Docker context names so tags and image references replace path separators and default to `root`

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e89f7b01288328a5d87089534cb2bd

## Summary by Sourcery

Add GitHub Actions workflow to build and publish backend, frontend, and python-worker Docker images with sanitized context-based tags

New Features:
- Add Docker build and publish workflow triggered on semantic version tag pushes or manual dispatch

Enhancements:
- Sanitize Docker context paths into lowercase, hyphen-separated suffixes with fallback to 'root'

Build:
- Use docker/build-push-action to build, tag, and push images to GHCR based on computed image references

CI:
- Set up Docker Buildx, log in to GitHub Container Registry, and compute image metadata within the workflow