### PR TITLE
Add sanitized image name handling for Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,71 @@
+name: Docker Images
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+  security-events: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ctx:
+          - .
+          - ./backend
+          - ./frontend
+          - ./python-worker
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive sanitized image name
+        id: sanitize
+        run: |
+          ctx="${{ matrix.ctx }}"
+          sanitized="${ctx#./}"
+          if [ -z "$sanitized" ] || [ "$sanitized" = "." ]; then
+            sanitized="root"
+          fi
+          sanitized="${sanitized//\//-}"
+          echo "name=$sanitized" >> "$GITHUB_OUTPUT"
+
+      - name: Build & push ${{ matrix.ctx }}
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.ctx }}
+          push: true
+          tags: ghcr.io/${{ github.repository }}:${{ steps.sanitize.outputs.name }}
+
+      - name: Trivy image scan ${{ matrix.ctx }}
+        uses: aquasecurity/trivy-action@0.20.0
+        with:
+          scan-type: image
+          image-ref: ghcr.io/${{ github.repository }}:${{ steps.sanitize.outputs.name }}
+          format: sarif
+          output: trivy-${{ steps.sanitize.outputs.name }}.sarif
+
+      - name: Upload Trivy scan results ${{ matrix.ctx }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-${{ steps.sanitize.outputs.name }}.sarif


### PR DESCRIPTION
## Summary
- add a docker build workflow that calculates a sanitized image name for each build context
- reuse the sanitized image name when tagging built images and running Trivy scans

## Testing
- act workflow_dispatch -W .github/workflows/docker.yml -j build --matrix ctx=./services/api --secret GITHUB_TOKEN=dummy --env DOCKER_BUILDKIT=1 *(fails: Docker is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e89f64e4448328b6eea4a4fbe910f0

## Summary by Sourcery

Add a GitHub Actions workflow to build, tag, scan, and push Docker images with sanitized names for each build context

New Features:
- Introduce a Docker build workflow that handles multiple build contexts via a matrix job
- Derive and apply sanitized image names for tagging images
- Incorporate Trivy vulnerability scans and upload SARIF-formatted reports to GitHub