### PR TITLE
Add missing customer id to inline interaction creation

### DIFF
--- a/frontend/src/pages/CustomerDetail.tsx
+++ b/frontend/src/pages/CustomerDetail.tsx
@@ -630,6 +630,7 @@ const AddInteractionModal: React.FC<AddInteractionModalProps> = ({ customerId, o
     try {
       setLoading(true);
       await interactionApi.create(customerId, {
+        customer_id: customerId,
         type: formData.type,
         summary: formData.summary,
         interaction_date: new Date(),

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -70,6 +70,7 @@ export const interactionApi = {
     interactionData: Omit<Interaction, 'id' | 'created_at' | 'updated_at'>
   ): Promise<Interaction> => {
     const payload: Record<string, unknown> = {
+      customer_id: interactionData.customer_id ?? customerId,
       type: interactionData.type,
       summary: interactionData.summary,
       notes: interactionData.notes,


### PR DESCRIPTION
## Summary
- include the required `customer_id` when the inline customer detail modal creates an interaction

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68f8d96540e4832881f4841bcbe1d977)

## Summary by Sourcery

Bug Fixes:
- Include the required customer_id in the payload for inline interaction creation