### PR TITLE
Enhance Frazer stage automation and add CRM e2e coverage

### DIFF
--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -7,7 +7,9 @@ import { User } from '../types';
 const JWT_SECRET = process.env.JWT_SECRET || 'supersecretjwtkey';
 
 export class AuthService {
-  private db = DatabaseManager.getInstance().getDb();
+  private get db() {
+    return DatabaseManager.getInstance().getDb();
+  }
 
   async registerUser(username: string, password_plain: string): Promise<User> {
     const hashedPassword = await bcrypt.hash(password_plain, 10);

--- a/backend/src/services/frazerStageConfig.ts
+++ b/backend/src/services/frazerStageConfig.ts
@@ -1,0 +1,142 @@
+import { InteractionType, PipelineStatus, ReminderType } from '../types';
+
+export interface FrazerStageDefinition {
+  status: PipelineStatus;
+  frazerStep: 'Talk' | 'Invite' | 'Show' | 'Keep Talking' | 'Enroll';
+  cadenceHours: number;
+  reminderType: ReminderType;
+  aiSignals: string[];
+  touchpoint: {
+    type: InteractionType;
+    summary: string;
+    notesHint: string;
+  };
+}
+
+const DEFAULT_STAGE_DEFINITION: FrazerStageDefinition = {
+  status: PipelineStatus.NEW_LEAD,
+  frazerStep: 'Talk',
+  cadenceHours: 24,
+  reminderType: ReminderType.FOLLOW_UP,
+  aiSignals: ['speed_of_follow_up'],
+  touchpoint: {
+    type: InteractionType.NOTE,
+    summary: 'Log first touchpoint',
+    notesHint: 'Capture tone + context for first contact'
+  }
+};
+
+export const FRAZER_STAGE_DEFINITIONS: FrazerStageDefinition[] = [
+  {
+    status: PipelineStatus.NEW_LEAD,
+    frazerStep: 'Talk',
+    cadenceHours: 24,
+    reminderType: ReminderType.FOLLOW_UP_24H,
+    aiSignals: ['speed_of_follow_up', 'lead_source_quality'],
+    touchpoint: {
+      type: InteractionType.CALL,
+      summary: 'Talk → Acknowledge new lead',
+      notesHint: 'Confirm how you met, mirror their energy, log objections'
+    }
+  },
+  {
+    status: PipelineStatus.WARMING_UP,
+    frazerStep: 'Invite',
+    cadenceHours: 36,
+    reminderType: ReminderType.FOLLOW_UP_2H,
+    aiSignals: ['micro_commitments', 'rapport_strength'],
+    touchpoint: {
+      type: InteractionType.NOTE,
+      summary: 'Warming Up → Seed the invitation',
+      notesHint: 'Share a quick win, confirm interest, document their WHY'
+    }
+  },
+  {
+    status: PipelineStatus.INVITED,
+    frazerStep: 'Invite',
+    cadenceHours: 48,
+    reminderType: ReminderType.FOLLOW_UP_48H,
+    aiSignals: ['invite_sent', 'accepted_invite'],
+    touchpoint: {
+      type: InteractionType.EMAIL,
+      summary: 'Invite → Confirm event/video details',
+      notesHint: 'Send link, reconfirm time, handle friction proactively'
+    }
+  },
+  {
+    status: PipelineStatus.QUALIFIED,
+    frazerStep: 'Show',
+    cadenceHours: 72,
+    reminderType: ReminderType.FOLLOW_UP_1D,
+    aiSignals: ['prospect_why', 'qualification_score'],
+    touchpoint: {
+      type: InteractionType.MEETING,
+      summary: 'Qualified → Share proof / presentation invite',
+      notesHint: 'Capture their WHY + outcome, confirm attendance'
+    }
+  },
+  {
+    status: PipelineStatus.PRESENTATION_SENT,
+    frazerStep: 'Show',
+    cadenceHours: 72,
+    reminderType: ReminderType.FOLLOW_UP_1D,
+    aiSignals: ['presentation_sent', 'show_rate'],
+    touchpoint: {
+      type: InteractionType.EMAIL,
+      summary: 'Show → Deliver presentation + action plan',
+      notesHint: 'Highlight key wins, answer objections, remind of next step'
+    }
+  },
+  {
+    status: PipelineStatus.FOLLOW_UP,
+    frazerStep: 'Keep Talking',
+    cadenceHours: 96,
+    reminderType: ReminderType.FOLLOW_UP_7D,
+    aiSignals: ['follow_up_count', 'objection_handling'],
+    touchpoint: {
+      type: InteractionType.CALL,
+      summary: 'Keep Talking → Collect decision / objection',
+      notesHint: 'Reiterate value, isolate objections, confirm decision date'
+    }
+  },
+  {
+    status: PipelineStatus.CLOSED_WON,
+    frazerStep: 'Enroll',
+    cadenceHours: 168,
+    reminderType: ReminderType.FOLLOW_UP,
+    aiSignals: ['enrollment', 'onboarding_speed'],
+    touchpoint: {
+      type: InteractionType.NOTE,
+      summary: 'Enroll → Onboard + celebrate',
+      notesHint: 'Capture launch tasks, tag accountability partner'
+    }
+  },
+  {
+    status: PipelineStatus.NOT_NOW,
+    frazerStep: 'Keep Talking',
+    cadenceHours: 240,
+    reminderType: ReminderType.FOLLOW_UP_7D,
+    aiSignals: ['nurture_needed', 'objection_type'],
+    touchpoint: {
+      type: InteractionType.NOTE,
+      summary: 'Not Now → Drop value + timeline reminder',
+      notesHint: 'Log objection, set revisit date, share success story'
+    }
+  },
+  {
+    status: PipelineStatus.LONG_TERM_NURTURE,
+    frazerStep: 'Keep Talking',
+    cadenceHours: 360,
+    reminderType: ReminderType.FOLLOW_UP,
+    aiSignals: ['nurture_sequence', 'content_engagement'],
+    touchpoint: {
+      type: InteractionType.EMAIL,
+      summary: 'Long-term Nurture → Deliver consistent value',
+      notesHint: 'Share proof, highlight wins, invite soft micro-commitment'
+    }
+  }
+];
+
+export function getStageDefinition(status: PipelineStatus): FrazerStageDefinition {
+  return FRAZER_STAGE_DEFINITIONS.find(def => def.status === status) || DEFAULT_STAGE_DEFINITION;
+}

--- a/backend/src/tests/automationService.test.ts
+++ b/backend/src/tests/automationService.test.ts
@@ -42,46 +42,42 @@ describe('AutomationService', () => {
   describe('handleEvent', () => {
     it('should create reminders for VIDEO_SENT event', async () => {
       const initialReminders: Reminder[] = await reminderService.getAllReminders();
-      expect(initialReminders.length).toBe(0);
 
       await automationService.handleEvent({ event_name: 'VIDEO_SENT', customer_id: testCustomerId });
 
       const newReminders: Reminder[] = await reminderService.getAllReminders();
-      expect(newReminders.length).toBe(2); // Expecting 2 reminders for VIDEO_SENT
+      expect(newReminders.length).toBe(initialReminders.length + 2); // Expecting 2 reminders for VIDEO_SENT
       expect(newReminders.some(r => r.type === 'follow_up_24h')).toBe(true);
       expect(newReminders.some(r => r.type === 'follow_up_48h')).toBe(true);
     });
 
     it('should create reminders for NO_SHOW event', async () => {
       const initialReminders: Reminder[] = await reminderService.getAllReminders();
-      expect(initialReminders.length).toBe(0);
 
       await automationService.handleEvent({ event_name: 'NO_SHOW', customer_id: testCustomerId });
 
       const newReminders: Reminder[] = await reminderService.getAllReminders();
-      expect(newReminders.length).toBe(2); // Expecting 2 reminders for NO_SHOW
+      expect(newReminders.length).toBe(initialReminders.length + 2); // Expecting 2 reminders for NO_SHOW
       expect(newReminders.some(r => r.type === 'follow_up_2h')).toBe(true);
       expect(newReminders.some(r => r.type === 'follow_up_1d')).toBe(true);
     });
 
     it('should not create reminders for unknown events', async () => {
       const initialReminders: Reminder[] = await reminderService.getAllReminders();
-      expect(initialReminders.length).toBe(0);
 
       await automationService.handleEvent({ event_name: 'UNKNOWN_EVENT', customer_id: testCustomerId });
 
       const newReminders: Reminder[] = await reminderService.getAllReminders();
-      expect(newReminders.length).toBe(0);
+      expect(newReminders.length).toBe(initialReminders.length);
     });
 
     it('should not create reminders if customer_id is missing', async () => {
       const initialReminders: Reminder[] = await reminderService.getAllReminders();
-      expect(initialReminders.length).toBe(0);
 
       await automationService.handleEvent({ event_name: 'VIDEO_SENT' });
 
       const newReminders: Reminder[] = await reminderService.getAllReminders();
-      expect(newReminders.length).toBe(0);
+      expect(newReminders.length).toBe(initialReminders.length);
     });
   });
 });

--- a/backend/src/tests/followUpService.test.ts
+++ b/backend/src/tests/followUpService.test.ts
@@ -42,16 +42,16 @@ describe('FollowUpService', () => {
   describe('createFollowUp', () => {
     it('should create a new follow-up for a customer', async () => {
       const initialReminders = await reminderService.getRemindersByCustomerId(testCustomerId);
-      expect(initialReminders.length).toBe(0);
+      const initialFollowUpCount = initialReminders.filter(r => r.type === ReminderType.FOLLOW_UP).length;
 
       await followUpService.createFollowUp(testCustomerId, PipelineStatus.PRESENTATION_SENT);
 
       const newReminders = await reminderService.getRemindersByCustomerId(testCustomerId);
-      expect(newReminders.length).toBe(1);
-      expect(newReminders[0].customer_id).toBe(testCustomerId);
-      expect(newReminders[0].type).toBe(ReminderType.FOLLOW_UP);
-      expect(newReminders[0].message).toBeDefined();
-      expect(newReminders[0].scheduled_for).toBeDefined();
+      const followUpReminders = newReminders.filter(r => r.type === ReminderType.FOLLOW_UP);
+      expect(followUpReminders.length).toBe(initialFollowUpCount + 1);
+      expect(followUpReminders[followUpReminders.length - 1].customer_id).toBe(testCustomerId);
+      expect(followUpReminders[followUpReminders.length - 1].message).toBeDefined();
+      expect(followUpReminders[followUpReminders.length - 1].scheduled_for).toBeDefined();
     });
   });
 

--- a/backend/src/tests/frazerPipeline.e2e.test.ts
+++ b/backend/src/tests/frazerPipeline.e2e.test.ts
@@ -1,0 +1,121 @@
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import express from 'express';
+import customerRoutes from '../routes/customers';
+import statsRoutes from '../routes/stats';
+import DatabaseManager from '../database';
+import { runMigrations } from '../database/migrate';
+import { PipelineStatus } from '../types';
+import { authenticateToken } from '../middleware/authMiddleware';
+
+const JWT_SECRET = process.env.JWT_SECRET || 'supersecretjwtkey';
+
+describe('Frazer pipeline end-to-end API', () => {
+  const dbManager = DatabaseManager.getInstance();
+  let token: string;
+  let app: express.Express;
+
+  beforeAll(async () => {
+    await dbManager.connect();
+    await resetDatabase();
+    await runMigrations();
+    app = buildTestApp();
+    token = jwt.sign({ sub: 'frazer-e2e', roles: ['admin'] }, JWT_SECRET);
+  });
+
+  afterAll(async () => {
+    await dbManager.close();
+  });
+
+  it('walks a lead through Frazer stages and emits telemetry', async () => {
+    const agent = request(app);
+    const headers = { Authorization: `Bearer ${token}` };
+
+    const createResponse = await agent
+      .post('/api/customers')
+      .set(headers)
+      .send({
+        name: 'Frazer API Test',
+        email: `frazer-${Date.now()}@example.com`,
+        status: PipelineStatus.NEW_LEAD,
+        notes: 'Stage-walk test'
+      })
+      .expect(201);
+
+    const customerId = createResponse.body.id;
+    expect(createResponse.body.status).toBe(PipelineStatus.NEW_LEAD);
+
+    const progressionTargets = [
+      PipelineStatus.WARMING_UP,
+      PipelineStatus.INVITED,
+      PipelineStatus.QUALIFIED,
+      PipelineStatus.PRESENTATION_SENT
+    ];
+
+    for (const expectedStage of progressionTargets) {
+      const response = await agent
+        .post(`/api/customers/${customerId}/next-stage`)
+        .set(headers)
+        .expect(200);
+
+      expect(response.body.status).toBe(expectedStage);
+    }
+
+    const stageTransitionCount = await countRows(
+      'SELECT COUNT(*) as c FROM event_logs WHERE customer_id = ? AND event_type = ?',
+      [customerId, 'frazer_stage_transition']
+    );
+    expect(stageTransitionCount).toBe(progressionTargets.length);
+
+    const reminderCount = await countRows(
+      'SELECT COUNT(*) as c FROM reminders WHERE customer_id = ? AND completed = 0',
+      [customerId]
+    );
+    expect(reminderCount).toBeGreaterThanOrEqual(1);
+
+    const statsResponse = await agent
+      .get('/api/customers/stats')
+      .set(headers)
+      .expect(200);
+
+    expect(statsResponse.body.counts_by_status[PipelineStatus.PRESENTATION_SENT]).toBeGreaterThanOrEqual(1);
+    expect(statsResponse.body.dmo_today).toBeDefined();
+    expect(statsResponse.body.overdue_followups).toBeDefined();
+  });
+});
+
+async function resetDatabase() {
+  const db = DatabaseManager.getInstance().getDb();
+  await new Promise<void>((resolve, reject) => {
+    db.exec(
+      'DROP TABLE IF EXISTS reminders; DROP TABLE IF EXISTS interactions; DROP TABLE IF EXISTS event_logs; DROP TABLE IF EXISTS customers;',
+      (err) => {
+        if (err) reject(err);
+        else resolve();
+      }
+    );
+  });
+}
+
+async function countRows(query: string, params: any[]): Promise<number> {
+  const db = DatabaseManager.getInstance().getDb();
+  return new Promise((resolve, reject) => {
+    db.get(query, params, (err, row: any) => {
+      if (err) return reject(err);
+      resolve(row?.c || row?.count || 0);
+    });
+  });
+}
+
+function buildTestApp() {
+  const app = express();
+  app.use(express.json());
+
+  const apiRouter = express.Router();
+  apiRouter.use(authenticateToken);
+  apiRouter.use('/customers', customerRoutes);
+  apiRouter.use('/stats', statsRoutes);
+
+  app.use('/api', apiRouter);
+  return app;
+}

--- a/backend/src/types/custom-modules.d.ts
+++ b/backend/src/types/custom-modules.d.ts
@@ -1,0 +1,2 @@
+declare module 'swagger-ui-express';
+declare module 'yamljs';

--- a/backend/src/utils/piiRedaction.ts
+++ b/backend/src/utils/piiRedaction.ts
@@ -1,0 +1,41 @@
+import logger from './logger';
+
+const SENSITIVE_KEYS = ['email', 'phone', 'token', 'password'];
+
+function sanitizeMeta(meta: unknown): Record<string, unknown> {
+  if (!meta) {
+    return {};
+  }
+
+  if (meta instanceof Error) {
+    return sanitizeMeta({ message: meta.message, stack: meta.stack });
+  }
+
+  if (typeof meta !== 'object') {
+    return {};
+  }
+
+  const cleanMeta: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(meta as Record<string, unknown>)) {
+    if (SENSITIVE_KEYS.includes(key.toLowerCase())) {
+      cleanMeta[key] = '[redacted]';
+    } else if (typeof value === 'object' && value !== null) {
+      cleanMeta[key] = sanitizeMeta(value);
+    } else {
+      cleanMeta[key] = value;
+    }
+  }
+  return cleanMeta;
+}
+
+function logWithSanitization(level: 'info' | 'error' | 'warn' | 'debug', message: string, meta?: unknown) {
+  const cleaned = sanitizeMeta(meta);
+  logger.log(level, message, cleaned);
+}
+
+export const safeLogger = {
+  info: (message: string, meta?: unknown) => logWithSanitization('info', message, meta),
+  error: (message: string, meta?: unknown) => logWithSanitization('error', message, meta),
+  warn: (message: string, meta?: unknown) => logWithSanitization('warn', message, meta),
+  debug: (message: string, meta?: unknown) => logWithSanitization('debug', message, meta),
+};


### PR DESCRIPTION
## Summary
- add a shared Frazer stage configuration and wire customer, reminder, and interaction services to honor cadence, AI scoring, and telemetry hooks
- introduce CRM stall analysis to the Python task generators so autonomous agents can create follow-up work items automatically
- add a Frazer pipeline API test plus refresh existing reminder/automation specs to respect the new nurture cadences

## Testing
- `npm run test:backend` *(fails: legacy suites still expect zero reminders/event logs and other modules remain unimplemented; see logs in chunk a26bb4)*
- `cd backend && npx jest src/tests/frazerPipeline.e2e.test.ts src/tests/interactionService.test.ts`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919067508ec832888225e7958a0dbfc)

## Summary by Sourcery

Introduce a unified Frazer stage framework to automate reminders, touchpoints, AI scoring and telemetry in customer pipelines; extend Python task generators to analyze CRM stalls and auto-create follow-up tasks; and add an end-to-end Frazer pipeline API test along with test updates across services.

New Features:
- Add central frazerStageConfig to define stage cadences, reminders, AI signals and touchpoints.
- Enhance CustomerService to assign next actions, schedule stage reminders, handle stage transitions with AI scoring and telemetry.
- Extend ReminderService with scheduleStageReminder and InteractionService with logFrazerTouchpoint and getActivityScore for automated follow-ups.
- Introduce CRM stall analysis in Python task generators to detect stalled leads and generate CRM automation tasks.

Enhancements:
- Refactor backend tests to adapt to dynamic reminder counts and streamline database resets.
- Simplify AuthService database access and add type declarations for external modules.
- Introduce PII redaction utility safeLogger for sanitized logging.

Tests:
- Add a Frazer pipeline end-to-end API test to validate stage progression, telemetry logging and reminder scheduling.
- Refresh interactionService, automationService and followUpService tests to respect the new nurture cadences.