### PR TITLE
Add cache-backed idempotency tests

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -11,5 +11,6 @@ module.exports = {
     'src/**/*.ts',
     '!src/**/*.d.ts',
   ],
+  setupFiles: ['<rootDir>/src/tests/setupRedisMock.ts'],
   setupFilesAfterEnv: ['<rootDir>/src/tests/setup.ts']
 };

--- a/backend/package.json
+++ b/backend/package.json
@@ -47,6 +47,7 @@
     "@typescript-eslint/eslint-plugin": "^6.4.0",
     "@typescript-eslint/parser": "^6.4.0",
     "eslint": "^8.47.0",
+    "ioredis-mock": "^8.13.1",
     "jest": "^29.6.2",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.1",

--- a/backend/src/middleware/idempotency.ts
+++ b/backend/src/middleware/idempotency.ts
@@ -1,9 +1,13 @@
 import { Request, Response, NextFunction } from 'express';
 import { safeLogger } from '../utils/piiRedaction';
-import { redisClient } from '../utils/cacheManager'; // Assuming cacheManager exports redisClient
+import { cacheManager } from '../utils/cacheManager';
 
 const IDEMPOTENCY_KEY_PREFIX = 'idempotency:';
 const IDEMPOTENCY_KEY_TTL = 60 * 60; // 1 hour
+const cacheOptions = {
+  prefix: IDEMPOTENCY_KEY_PREFIX,
+  ttl: IDEMPOTENCY_KEY_TTL,
+};
 
 /**
  * Middleware to ensure idempotency for API requests.
@@ -16,14 +20,16 @@ export async function idempotencyMiddleware(req: Request, res: Response, next: N
     return next(); // No idempotency key provided, proceed as normal
   }
 
-  const cacheKey = IDEMPOTENCY_KEY_PREFIX + idempotencyKey;
-
   try {
-    const cachedResponse = await redisClient.get(cacheKey);
+    const cachedResponse = await cacheManager.get<{
+      statusCode: number;
+      headers: Record<string, number | string | string[]>;
+      body: unknown;
+    }>(idempotencyKey, cacheOptions);
 
     if (cachedResponse) {
       safeLogger.info(`Idempotency: Returning cached response for key: ${idempotencyKey}`);
-      const { statusCode, headers, body } = JSON.parse(cachedResponse);
+      const { statusCode, headers, body } = cachedResponse;
       res.status(statusCode).set(headers).send(body);
       return;
     }
@@ -36,7 +42,8 @@ export async function idempotencyMiddleware(req: Request, res: Response, next: N
         headers: res.getHeaders(),
         body: body,
       };
-      redisClient.setex(cacheKey, IDEMPOTENCY_KEY_TTL, JSON.stringify(responseToCache))
+      cacheManager
+        .set(idempotencyKey, responseToCache, cacheOptions)
         .catch(err => safeLogger.error(`Idempotency: Failed to cache response for key ${idempotencyKey}`, err));
       return originalSend.apply(res, [body]);
     };

--- a/backend/src/tests/idempotencyMiddleware.test.ts
+++ b/backend/src/tests/idempotencyMiddleware.test.ts
@@ -1,0 +1,68 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { idempotencyMiddleware } from '../middleware/idempotency';
+import { cacheManager } from '../utils/cacheManager';
+
+describe('idempotency middleware', () => {
+  let app: express.Express;
+
+  beforeEach(async () => {
+    app = express();
+    app.use(express.json());
+    app.use(idempotencyMiddleware);
+
+    app.post('/test-resource', (_req: Request, res: Response) => {
+      res.status(201).json({
+        method: 'POST',
+        payloadId: `${Date.now()}-${Math.random()}`,
+      });
+    });
+
+    app.put('/test-resource', (_req: Request, res: Response) => {
+      res.status(200).json({
+        method: 'PUT',
+        payloadId: `${Date.now()}-${Math.random()}`,
+      });
+    });
+
+    await cacheManager.clear();
+  });
+
+  it('replays cached POST response when the same idempotency key is reused', async () => {
+    const key = 'post-key';
+
+    const firstResponse = await request(app)
+      .post('/test-resource')
+      .set('X-Idempotency-Key', key)
+      .send({ value: 'alpha' })
+      .expect(201);
+
+    const secondResponse = await request(app)
+      .post('/test-resource')
+      .set('X-Idempotency-Key', key)
+      .send({ value: 'alpha' })
+      .expect(201);
+
+    expect(secondResponse.body).toEqual(firstResponse.body);
+    expect(secondResponse.headers['content-type']).toEqual(firstResponse.headers['content-type']);
+  });
+
+  it('replays cached PUT response when the same idempotency key is reused', async () => {
+    const key = 'put-key';
+
+    const firstResponse = await request(app)
+      .put('/test-resource')
+      .set('X-Idempotency-Key', key)
+      .send({ value: 'beta' })
+      .expect(200);
+
+    const secondResponse = await request(app)
+      .put('/test-resource')
+      .set('X-Idempotency-Key', key)
+      .send({ value: 'beta' })
+      .expect(200);
+
+    expect(secondResponse.body).toEqual(firstResponse.body);
+    expect(secondResponse.headers['content-type']).toEqual(firstResponse.headers['content-type']);
+  });
+});

--- a/backend/src/tests/setupRedisMock.ts
+++ b/backend/src/tests/setupRedisMock.ts
@@ -1,0 +1,4 @@
+// Ensure Redis operations use an in-memory mock during tests
+jest.mock('ioredis', () => require('ioredis-mock'));
+
+export {};

--- a/backend/src/utils/piiRedaction.ts
+++ b/backend/src/utils/piiRedaction.ts
@@ -1,0 +1,31 @@
+import logger from './logger';
+
+type LogMeta = Record<string, unknown> | undefined;
+
+const redactMeta = (meta?: unknown): LogMeta => {
+  if (!meta || typeof meta !== 'object' || Array.isArray(meta)) {
+    return meta as LogMeta;
+  }
+
+  const clone: Record<string, unknown> = { ...(meta as Record<string, unknown>) };
+
+  if ('password' in clone) {
+    clone.password = '[REDACTED]';
+  }
+  if ('token' in clone) {
+    clone.token = '[REDACTED]';
+  }
+  if ('authorization' in clone) {
+    clone.authorization = '[REDACTED]';
+  }
+  return clone;
+};
+
+export const safeLogger = {
+  info: (message: string, meta?: unknown) => logger.info(message, redactMeta(meta)),
+  warn: (message: string, meta?: unknown) => logger.warn(message, redactMeta(meta)),
+  error: (message: string, meta?: unknown) => logger.error(message, redactMeta(meta)),
+  debug: (message: string, meta?: unknown) => logger.debug(message, redactMeta(meta)),
+};
+
+export default safeLogger;

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "@typescript-eslint/eslint-plugin": "^6.4.0",
         "@typescript-eslint/parser": "^6.4.0",
         "eslint": "^8.47.0",
+        "ioredis-mock": "^8.13.1",
         "jest": "^29.6.2",
         "supertest": "^6.3.3",
         "ts-jest": "^29.1.1",
@@ -1538,6 +1539,13 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@ioredis/as-callback": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/as-callback/-/as-callback-3.0.0.tgz",
+      "integrity": "sha512-Kqv1rZ3WbgOrS+hgzJ5xG5WQuhvzzSTRYvNeyPMLOAM78MHSnuKI20JeJGbpuAt//LCuP0vsexZcorqW7kWhJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@ioredis/commands": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.4.0.tgz",
@@ -2947,6 +2955,17 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ioredis-mock": {
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/@types/ioredis-mock/-/ioredis-mock-8.2.6.tgz",
+      "integrity": "sha512-5heqtZMvQ4nXARY0o8rc8cjkJjct2ScM12yCJ/h731S9He93a2cv+kAhwPCNwTKDfNH9gjRfLG4VpAEYJU0/gQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "ioredis": ">=5"
       }
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -6422,6 +6441,35 @@
       "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
       "license": "MIT"
     },
+    "node_modules/fengari": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/fengari/-/fengari-0.1.4.tgz",
+      "integrity": "sha512-6ujqUuiIYmcgkGz8MGAdERU57EIluGGPSUgGPTsco657EHa+srq0S3/YUl/r9kx1+D+d4rGfYObd+m8K22gB1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readline-sync": "^1.4.9",
+        "sprintf-js": "^1.1.1",
+        "tmp": "^0.0.33"
+      }
+    },
+    "node_modules/fengari-interop": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/fengari-interop/-/fengari-interop-0.1.3.tgz",
+      "integrity": "sha512-EtZ+oTu3kEwVJnoymFPBVLIbQcCoy9uWCVnMA6h3M/RqHkUBsLYp29+RRHf9rKr6GwjubWREU1O7RretFIXjHw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "fengari": "^0.1.0"
+      }
+    },
+    "node_modules/fengari/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -7407,6 +7455,27 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ioredis-mock": {
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/ioredis-mock/-/ioredis-mock-8.13.1.tgz",
+      "integrity": "sha512-Wsi50AU+cMiI32nAgfwpUaJVBtb4iQdVsOHl9M6R3tePCO/8vGsToCVIG82XWAxN4Se55TZoOzVseu+QngFLyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/as-callback": "^3.0.0",
+        "@ioredis/commands": "^1.4.0",
+        "fengari": "^0.1.4",
+        "fengari-interop": "^0.1.3",
+        "semver": "^7.7.2"
+      },
+      "engines": {
+        "node": ">=12.22"
+      },
+      "peerDependencies": {
+        "@types/ioredis-mock": "^8",
+        "ioredis": "^5"
       }
     },
     "node_modules/ip-address": {
@@ -9873,6 +9942,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -10980,6 +11059,16 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readline-sync": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
+      "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/redent": {
@@ -12645,6 +12734,19 @@
       "integrity": "sha512-XHhPmHxphLi+LGbH0G/O7dmUH9V65OY20R7vH8gETHsp5AZCjBk9l8sqmRKLaGOxnETU7XNSDUPtewAy/K6jbA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",


### PR DESCRIPTION
## Summary
- refactor the idempotency middleware to consume the shared cache manager and log safe responses
- introduce a safe logger implementation and a Redis mock setup so tests can exercise the middleware without a live server
- add integration tests that verify POST and PUT requests reuse cached responses when the same X-Idempotency-Key header is supplied

## Testing
- npm test -- idempotencyMiddleware

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919569726e08328a8702553fcb3222d)

## Summary by Sourcery

Enhance the idempotency middleware by switching to a cache-backed implementation and adding safe logging, and validate its behavior with mocked Redis integration tests.

New Features:
- Add integration tests to verify that POST and PUT requests return cached responses when supplied the same X-Idempotency-Key

Enhancements:
- Refactor idempotency middleware to use the shared cacheManager with configurable prefix and TTL
- Introduce safeLogger utility that redacts sensitive fields (password, token, authorization) in log metadata
- Configure Jest to mock Redis using ioredis-mock for in-memory cache testing

Build:
- Add ioredis-mock as a development dependency

Tests:
- Add setupRedisMock to initialize the Redis mock for tests
- Introduce idempotencyMiddleware integration tests