### PR TITLE
Add safe logger wrapper and tests

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,6 +68,12 @@ Please include the following information in your report:
 - Use parameterized queries to prevent SQL injection
 - Keep dependencies updated and scan for vulnerabilities
 
+### Logging Contract
+
+- Always import `safeLogger` from `backend/src/utils/piiRedaction.ts` when writing application logs. The wrapper applies the Winston redactors defined in `logger.ts`, recursively masks sensitive metadata fields (passwords, tokens, emails, phone numbers, SSNs, etc.), and automatically enriches entries with request-scoped correlation IDs.
+- Never instantiate or import raw Winston loggers in feature code. Doing so bypasses the masking logic, risks leaking PII, and can break the correlation-ID middleware in `backend/src/middleware/correlationId.ts`.
+- Treat all new structured log fields as potentially sensitive; if you introduce a novel credential- or identifier-like key, add it to the `SENSITIVE_FIELDS` allowlist in `piiRedaction.ts` so future messages are sanitized consistently.
+
 ## Security Features
 
 Flowstate-AI implements the following security measures:

--- a/backend/src/middleware/correlationId.ts
+++ b/backend/src/middleware/correlationId.ts
@@ -25,17 +25,29 @@ export function correlationIdMiddleware(req: Request, res: Response, next: NextF
   const originalError = safeLogger.error;
   const originalDebug = safeLogger.debug;
 
+  const normalizeMeta = (meta?: unknown): Record<string, unknown> => {
+    if (meta && typeof meta === 'object' && !Array.isArray(meta)) {
+      return meta as Record<string, unknown>;
+    }
+
+    if (meta === undefined || meta === null) {
+      return {};
+    }
+
+    return { data: meta };
+  };
+
   safeLogger.info = (message: string, meta?: unknown) => {
-    originalInfo(message, { correlationId, ...meta });
+    originalInfo(message, { correlationId, ...normalizeMeta(meta) });
   };
   safeLogger.warn = (message: string, meta?: unknown) => {
-    originalWarn(message, { correlationId, ...meta });
+    originalWarn(message, { correlationId, ...normalizeMeta(meta) });
   };
   safeLogger.error = (message: string, meta?: unknown) => {
-    originalError(message, { correlationId, ...meta });
+    originalError(message, { correlationId, ...normalizeMeta(meta) });
   };
   safeLogger.debug = (message: string, meta?: unknown) => {
-    originalDebug(message, { correlationId, ...meta });
+    originalDebug(message, { correlationId, ...normalizeMeta(meta) });
   };
 
   // Reset logger functions after the request is processed

--- a/backend/src/tests/piiRedaction.test.ts
+++ b/backend/src/tests/piiRedaction.test.ts
@@ -1,0 +1,92 @@
+import EventEmitter from 'events';
+import type { Request, Response, NextFunction } from 'express';
+
+jest.mock('../utils/logger', () => {
+  const info = jest.fn();
+  const warn = jest.fn();
+  const error = jest.fn();
+  const debug = jest.fn();
+
+  return {
+    __esModule: true,
+    default: {
+      info,
+      warn,
+      error,
+      debug,
+    },
+  };
+});
+
+import logger from '../utils/logger';
+import { safeLogger } from '../utils/piiRedaction';
+import { correlationIdMiddleware } from '../middleware/correlationId';
+
+describe('safeLogger PII redaction', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('masks sensitive fields before delegating to the base logger', () => {
+    const meta = {
+      email: 'user@example.com',
+      nested: {
+        password: 'super-secret',
+        profile: {
+          token: 'abc123',
+          safe: 'value',
+        },
+      },
+      auditTrail: [
+        { refreshToken: 'def456', action: 'login' },
+      ],
+    };
+
+    safeLogger.info('user login', meta);
+
+    expect(logger.info).toHaveBeenCalledWith('user login', {
+      email: '[REDACTED]',
+      nested: {
+        password: '[REDACTED]',
+        profile: {
+          token: '[REDACTED]',
+          safe: 'value',
+        },
+      },
+      auditTrail: [
+        { refreshToken: '[REDACTED]', action: 'login' },
+      ],
+    });
+  });
+});
+
+class MockResponse extends EventEmitter {
+  public setHeader = jest.fn();
+}
+
+describe('correlationId middleware', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('adds the correlation ID to all log metadata', () => {
+    const req = {
+      headers: {},
+    } as Request;
+    const res = new MockResponse() as unknown as Response;
+    const next = jest.fn() as NextFunction;
+
+    correlationIdMiddleware(req, res, next);
+
+    safeLogger.info('processing request', { action: 'ping' });
+
+    expect(logger.info).toHaveBeenCalledWith(
+      'processing request',
+      expect.objectContaining({
+        action: 'ping',
+        correlationId: req.correlationId,
+      }),
+    );
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/backend/src/utils/piiRedaction.ts
+++ b/backend/src/utils/piiRedaction.ts
@@ -1,0 +1,93 @@
+import type winston from 'winston';
+import logger from './logger';
+
+const SENSITIVE_FIELDS = [
+  'password',
+  'token',
+  'accessToken',
+  'refreshToken',
+  'secret',
+  'apiKey',
+  'apikey',
+  'authorization',
+  'auth',
+  'email',
+  'phone',
+  'ssn',
+  'socialSecurityNumber',
+  'creditCard',
+  'cardNumber',
+];
+
+const REDACTED_VALUE = '[REDACTED]';
+const SENSITIVE_FIELD_SET = new Set(SENSITIVE_FIELDS.map(field => field.toLowerCase()));
+
+type LogFunction = (message: string, meta?: unknown) => winston.Logger | void;
+
+const maskValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(() => REDACTED_VALUE);
+  }
+
+  if (value && typeof value === 'object') {
+    return REDACTED_VALUE;
+  }
+
+  return REDACTED_VALUE;
+};
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> => {
+  if (value === null) {
+    return false;
+  }
+
+  if (Array.isArray(value)) {
+    return false;
+  }
+
+  return typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype;
+};
+
+const sanitizeValue = (value: unknown, parentKey?: string): unknown => {
+  if (parentKey && SENSITIVE_FIELD_SET.has(parentKey.toLowerCase())) {
+    return maskValue(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(entry => sanitizeValue(entry));
+  }
+
+  if (isPlainObject(value)) {
+    return Object.entries(value).reduce<Record<string, unknown>>((acc, [key, entry]) => {
+      acc[key] = sanitizeValue(entry, key);
+      return acc;
+    }, {});
+  }
+
+  return value;
+};
+
+const sanitizeMeta = (meta?: unknown): unknown => {
+  if (meta === undefined || meta === null) {
+    return meta;
+  }
+
+  if (Array.isArray(meta) || isPlainObject(meta)) {
+    return sanitizeValue(meta);
+  }
+
+  return meta;
+};
+
+const wrapLogFunction = (fn: LogFunction): LogFunction => {
+  return (message: string, meta?: unknown) => fn(message, sanitizeMeta(meta));
+};
+
+export const safeLogger = {
+  info: wrapLogFunction(logger.info.bind(logger)),
+  warn: wrapLogFunction(logger.warn.bind(logger)),
+  error: wrapLogFunction(logger.error.bind(logger)),
+  debug: wrapLogFunction(logger.debug.bind(logger)),
+};
+
+export default safeLogger;


### PR DESCRIPTION
## Summary
- add a dedicated `safeLogger` wrapper so every caller automatically receives the Winston-based PII redaction
- harden the correlation-ID middleware and add tests that cover both the redaction behaviour and correlation ID enrichment
- document the logging contract in `SECURITY.md` so contributors know to rely on `safeLogger`

## Testing
- `npm test` *(fails: existing TypeScript issues in interactionService.test.ts and shutdown.test.ts)*
- `npx jest src/tests/piiRedaction.test.ts`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69195208270c83288ad80a98b5e609b7)

## Summary by Sourcery

Implement a secure logging layer by adding a safeLogger wrapper for automatic PII redaction, hardening the correlation ID middleware, documenting the logging contract, and covering these behaviors with tests

New Features:
- Introduce safeLogger wrapper that applies PII redaction to all log calls

Enhancements:
- Enhance correlationIdMiddleware to normalize metadata and attach request-scoped correlation IDs to logs

Documentation:
- Add logging contract to SECURITY.md mandating safeLogger usage and PII masking

Tests:
- Add tests verifying safeLogger PII redaction and correlation ID enrichment in logs