### PR TITLE
Protect KPI routes with JWT auth and add tests

### DIFF
--- a/backend/src/routes/kpis.ts
+++ b/backend/src/routes/kpis.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { requireAuth } from '../middleware/auth';
+import { authenticateToken } from '../middleware/authMiddleware';
 import { safeLogger } from '../utils/piiRedaction';
 
 const router = Router();
@@ -35,7 +35,7 @@ const mockKpis = {
   ],
 };
 
-router.get('/', requireAuth, (req, res) => {
+router.get('/', authenticateToken, (req, res) => {
   const category = req.query.category as string;
   if (category && mockKpis[category as keyof typeof mockKpis]) {
     safeLogger.info(`Fetching KPIs for category: ${category}`);

--- a/backend/src/tests/kpiRoutes.test.ts
+++ b/backend/src/tests/kpiRoutes.test.ts
@@ -1,0 +1,36 @@
+import express from 'express';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+
+import kpiRoutes from '../routes/kpis';
+
+const JWT_SECRET = process.env.JWT_SECRET || 'supersecretjwtkey';
+
+describe('KPI Routes Authentication', () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/kpis', kpiRoutes);
+
+  it('should return 401 when no token is provided', async () => {
+    const response = await request(app).get('/api/kpis?category=executive');
+    expect(response.status).toBe(401);
+  });
+
+  it('should return 403 for invalid tokens', async () => {
+    const response = await request(app)
+      .get('/api/kpis?category=executive')
+      .set('Authorization', 'Bearer invalid-token');
+    expect(response.status).toBe(403);
+  });
+
+  it('should return KPI data when provided a valid JWT', async () => {
+    const token = jwt.sign({ userId: 'test-user' }, JWT_SECRET);
+    const response = await request(app)
+      .get('/api/kpis?category=executive')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    expect(Array.isArray(response.body)).toBe(true);
+    expect(response.body.length).toBeGreaterThan(0);
+  });
+});

--- a/backend/src/utils/piiRedaction.ts
+++ b/backend/src/utils/piiRedaction.ts
@@ -1,0 +1,9 @@
+import logger from './logger';
+
+// `logger` already applies basic PII redaction via its formatter. This module
+// exposes a `safeLogger` helper so other parts of the application can import a
+// consistent sanitized logger without depending directly on the logger
+// implementation.
+export const safeLogger = logger;
+
+export default safeLogger;


### PR DESCRIPTION
## Summary
- switch the KPI router to use the existing `authenticateToken` middleware so it matches the rest of the protected API surface
- add a simple `safeLogger` re-export to satisfy existing imports expecting `piiRedaction`
- add Jest coverage for the KPI router to ensure it enforces 401/403 responses for missing/invalid JWTs while allowing access with a valid token

## Testing
- npm test -- kpiRoutes

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69195a328e088328874496acd76dca18)

## Summary by Sourcery

Secure KPI API endpoints with the shared JWT authentication middleware, centralize the safeLogger export, and add coverage tests to validate authorization flows

New Features:
- Enforce JWT token authentication on KPI routes

Tests:
- Add Jest integration tests to verify 401 for missing tokens, 403 for invalid tokens, and 200 for valid JWTs on KPI routes

Chores:
- Introduce safeLogger re-export for consistent PII-redacted logging