### PR TITLE
Add API adapter export and logger utility

### DIFF
--- a/frontend/src/pages/KPIDashboard.tsx
+++ b/frontend/src/pages/KPIDashboard.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Card, Title, Text, Metric, Flex, ProgressBar, Badge, TabGroup, TabList, Tab, TabPanels, TabPanel } from '@tremor/react';
 import { ChartBarIcon, ChartPieIcon, ArrowUpIcon, ArrowDownIcon, ExclamationTriangleIcon, CheckCircleIcon } from '@heroicons/react/24/outline';
 import { LineChart, BarChart } from '@tremor/react';
-import { api } from '../services/api';
+import api from '../services/api';
 import logger from '../utils/logger';
 
 interface KPI {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -138,3 +138,5 @@ export const aiCoordinationApi = {
   },
 };
 
+export default axiosInstance;
+

--- a/frontend/src/utils/logger.ts
+++ b/frontend/src/utils/logger.ts
@@ -1,0 +1,31 @@
+const isDev = typeof import.meta !== 'undefined' ? !!import.meta.env?.DEV : true;
+const prefix = '[Flowstate-AI]';
+
+type LogArgs = [message?: any, ...optionalParams: any[]];
+
+type Logger = {
+  debug: (...args: LogArgs) => void;
+  info: (...args: LogArgs) => void;
+  warn: (...args: LogArgs) => void;
+  error: (...args: LogArgs) => void;
+};
+
+const createLogger = (): Logger => {
+  const log = (level: 'debug' | 'info' | 'warn' | 'error', ...args: LogArgs) => {
+    if (level === 'debug' && !isDev) return;
+
+    const consoleMethod = console[level] ?? console.log;
+    consoleMethod(prefix, ...args);
+  };
+
+  return {
+    debug: (...args) => log('debug', ...args),
+    info: (...args) => log('info', ...args),
+    warn: (...args) => log('warn', ...args),
+    error: (...args) => log('error', ...args),
+  };
+};
+
+const logger = createLogger();
+
+export default logger;


### PR DESCRIPTION
## Summary
- export the shared Axios instance as a default API adapter so screens such as the KPI dashboard can call `api.get`
- update the KPI dashboard to consume the adapter and log fetch failures through a common logger
- add a lightweight logger utility that wraps `console` for consistent logging in the frontend

## Testing
- `npm run test:run` *(fails: `QualificationQuestionnaire > calls onCancel when cancel button is clicked` already fails on main)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69195b6a85b48328b9d35da89f1b09b1)

## Summary by Sourcery

Introduce a shared API adapter and a frontend logger utility, and update the KPI dashboard to use them for fetching data and logging errors.

New Features:
- Export the shared Axios instance as the default API adapter
- Add a lightweight logger utility wrapping console for consistent frontend logging

Enhancements:
- Update the KPI dashboard to consume the new API adapter and log fetch failures via the common logger