### PR TITLE
chore: cleanup workspace - ignore local artifacts and add cleanup scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,8 @@ playwright/.cache/
 
 # Databases
 *.db
+.venv/
+tmp_
+*.csv
+GODMODE-BACKUP/
+godmode-logs/

--- a/docs/CLEANUP-dry-run.md
+++ b/docs/CLEANUP-dry-run.md
@@ -1,0 +1,38 @@
+# Flowstate-AI: CLEANUP dry run
+
+This document summarizes the dry-run repo audit and recommended cleanup steps. No destructive changes are performed by the scripts in `/scripts` unless explicitly requested.
+
+## Key observations (from local audit)
+
+- Local `.venv` exists and is large (≈1.3GB). It should be excluded from the repo and removed from git index if tracked.
+- `node_modules/` and `frontend/node_modules` are large but normally gitignored. Verify they are excluded by `.gitignore`.
+- `godmode-logs/` and `GODMODE-BACKUP/` contain runtime logs and backups; they should be excluded or moved to `archive/`.
+- Temporary audit files (e.g., `tmp_file_sizes.csv`, `tmp_git_ls_files.txt`) are present and should be ignored.
+- There are reparse points (symlinks) inside `node_modules` that may link outside the repo; confirm they are intentional.
+
+## Recommended changes (no-op unless you approve)
+
+1. Add `.venv/`, `tmp_*`, `*.csv`, `GODMODE-BACKUP/`, and `godmode-logs/` to `.gitignore`.
+2. If `.venv` or other noisy directories are tracked, remove them from the index: `git rm -r --cached .venv` and re-commit. This untracks files but preserves them on disk.
+3. Move large historical or raw docs to `docs/raw_archive/` and add that path to `.gitignore` if they are not essential for active development.
+4. Create `archive/` for backups and add an archive script to cleanly move old logs or large binary files outside the active repository.
+
+## Next steps (approve before applying)
+
+Run `scripts/cleanup_dryrun.ps1` to produce a full report and an actionable command list. To actually apply the changes, re-run with the `-apply` flag (careful—this will modify `.gitignore` and run `git rm --cached` for tracked items).
+
+## Non-destructive commands to run locally to replicate the audit
+
+```powershell
+Set-Location 'C:\Flowstate Project\Flowstate-AI'
+# show tracked differences
+git status --porcelain --untracked-files=all
+# show top 20 largest files
+Get-ChildItem -Path . -Recurse -File | Sort-Object Length -Descending | Select-Object -First 20 FullName,Length
+# show symlinks
+Get-ChildItem -Recurse -Force | Where-Object { ($_.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0 }
+```
+
+## Legal & Safety
+
+Do not run destructive scripts on production clones. Back up the repository before applying `git rm` or `git reset --hard`.

--- a/scripts/backup_repo.ps1
+++ b/scripts/backup_repo.ps1
@@ -1,0 +1,17 @@
+param(
+    [string]$repoPath = "C:\Flowstate Project\Flowstate-AI",
+    [string]$dest = "archive/backups"
+)
+
+Set-StrictMode -Version Latest
+if (-not (Test-Path -LiteralPath $repoPath)) { Write-Error "repoPath not found: $repoPath"; exit 1 }
+Set-Location -LiteralPath $repoPath
+
+$ts = Get-Date -Format yyyyMMddHHmmss
+$backupDir = Join-Path -Path $repoPath -ChildPath $dest
+if (-not (Test-Path -LiteralPath $backupDir)) { New-Item -ItemType Directory -Path $backupDir -Force | Out-Null }
+$archiveFile = Join-Path -Path $backupDir -ChildPath ("backup_{0}.zip" -f $ts)
+
+Write-Host "Creating repo archive: $archiveFile"
+Compress-Archive -Path (Get-ChildItem -Path $repoPath -Force | Where-Object { $_.FullName -ne $archiveFile }) -DestinationPath $archiveFile -Force
+Write-Host "Backup saved to: $archiveFile"

--- a/scripts/cleanup_dryrun.ps1
+++ b/scripts/cleanup_dryrun.ps1
@@ -1,0 +1,61 @@
+param(
+    [switch]$apply
+)
+
+Set-StrictMode -Version Latest
+$repoPath = 'C:\Flowstate Project\Flowstate-AI'
+if (-not (Test-Path -LiteralPath $repoPath)) { Write-Host "ERROR: repoPath not found: $repoPath"; exit 1 }
+Set-Location -LiteralPath $repoPath
+
+Write-Host "=== Repo Cleanup Dry Run ==="
+Write-Host "Repo: $repoPath"
+
+Write-Host "Counting files and top offenders..."
+$files = Get-ChildItem -Path . -Recurse -File -ErrorAction SilentlyContinue
+Write-Host ('Found files: ' + ($files | Measure-Object).Count)
+
+Write-Host "Top 30 largest files (FullPath, bytes):"
+$largest = $files | Sort-Object Length -Descending | Select-Object FullName, Length -First 30
+$largest | ForEach-Object { Write-Host ($_.FullName + ',' + $_.Length) }
+
+Write-Host "Noisy directories to consider: .venv, node_modules, godmode-logs, GODMODE-BACKUP"
+foreach ($d in @('.venv', 'node_modules', 'frontend\node_modules', 'godmode-logs', 'GODMODE-BACKUP')) {
+    if (Test-Path $d) { $size = (Get-ChildItem -Path $d -Recurse -File -ErrorAction SilentlyContinue | Measure-Object -Property Length -Sum).Sum; Write-Host ("$d : $size bytes") } else { Write-Host ("$d : not present") }
+}
+
+Write-Host "Detected reparse points/junctions and potential symlinks:"
+Get-ChildItem -Recurse -Force -ErrorAction SilentlyContinue | Where-Object { ($_.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0 } | Select-Object FullName, Attributes | Format-Table -AutoSize
+
+Write-Host "Suggested gitignore entries (verify):"
+$suggested = @('.venv/', 'tmp_*', '*.csv', 'GODMODE-BACKUP/', 'godmode-logs/')
+$suggested | ForEach-Object { Write-Host "  $_" }
+
+Write-Host "Suggested git commands (no-op until you approve):"
+Write-Host "  # Append suggested patterns to .gitignore if not present"
+Write-Host "  # git add .gitignore && git commit -m 'chore: ignore local virtual env, tmp files, logs'"
+Write-Host "  # If .venv is tracked: git rm -r --cached .venv && git commit -m 'chore: untrack .venv'"
+Write-Host "  # Optionally: move big files to archive/ and add an entry: 'archive/' to .gitignore"
+
+if ($apply) {
+    Write-Host "APPLY: Append suggested entries to .gitignore and run git rm --cached for tracked noisy directories"
+    # Append entries to .gitignore if missing
+    foreach ($line in $suggested) {
+        if (-not (Select-String -Path .gitignore -Pattern ([Regex]::Escape($line)) -Quiet)) {
+            Add-Content -Path .gitignore -Value $line
+            Write-Host "Appended $line to .gitignore"
+        }
+        else {
+            Write-Host "$line already present in .gitignore"
+        }
+    }
+    # If .venv is tracked, remove from index
+    if (git ls-files --error-unmatch .venv 2>$null) {
+        Write-Host ".venv is tracked; removing from index (git rm -r --cached .venv)"
+        git rm -r --cached .venv
+    }
+    else { Write-Host ".venv not tracked by git" }
+    Write-Host "Apply phase complete. Please inspect changes and commit them if acceptable."
+}
+else {
+    Write-Host "Dry-run mode. To apply changes, rerun with -apply"
+}


### PR DESCRIPTION
This PR adds a cleanup plan: ignored patterns for local artifacts (.venv, tmp, csv), adds scripts for repo backup and dry-run cleanup, and documents cleanup steps in docs/CLEANUP-dry-run.md. This is a non-destructive change; additional PR will untrack .venv if approved.

Please review and merge if acceptable.

## Summary by Sourcery

Provide workspace cleanup tooling and guidelines by extending .gitignore rules, adding PowerShell scripts for dry-run cleanup and backups, and documenting the cleanup process.

Enhancements:
- add cleanup_dryrun.ps1 and backup_repo.ps1 scripts to automate repository audit, cleanup dry-run, and backups

Documentation:
- add docs/CLEANUP-dry-run.md to summarize audit observations and recommend cleanup steps

Chores:
- extend .gitignore to ignore common local artifacts (.venv/, tmp_*, *.csv, logs, backups) and prepare for untracking tracked directories